### PR TITLE
Fix key name in documentation

### DIFF
--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -131,7 +131,7 @@ def scrublet(
         ``.obs['doublet_score']``
             Doublet scores for each observed transcriptome
 
-        ``.obs['predicted_doublets']``
+        ``.obs['predicted_doublet']``
             Boolean indicating predicted doublet status
 
         ``.uns['scrublet']['doublet_scores_sim']``


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

This PR fixes a typo in the docstring of `scanpy.external.pp.scrublet()`: The `obs` column is actually called `predicted_doublet` instead of `predicted_doublets`.